### PR TITLE
feat: add download button for the filtered dataframe

### DIFF
--- a/code/Home.py
+++ b/code/Home.py
@@ -12,7 +12,7 @@ Example queries:
 
 """
 
-__ver__ = 'v2.4.0'
+__ver__ = 'v2.4.1'
 
 import pandas as pd
 import streamlit as st

--- a/code/util/streamlit.py
+++ b/code/util/streamlit.py
@@ -9,6 +9,7 @@ from pandas.api.types import (
     is_numeric_dtype,
     is_string_dtype,
 )
+import json
 import streamlit.components.v1 as components
 from streamlit_plotly_events import plotly_events
 
@@ -689,13 +690,29 @@ def _add_download_filtered_session():
     """Download the master table of the filtered session"""
     # Convert DataFrame to CSV format
     csv = st.session_state.df_session_filtered.to_csv(index=False)
-
-    # Create a download button
+    
+    # Get the queries from URL for reproducibility
+    filters = {key: st.query_params.get_all(key)
+               for key in st.query_params.to_dict().keys()
+               if 'filter' in key}
+    query = json.dumps(filters, indent=4) 
+    
+    current_time = datetime.now().strftime("%Y%m%d_%H%M%S")
+    
+    # Create download buttons
     st.download_button(
-        label="💾 Download filtered df",
+        label="Download filtered df as CSV",
         data=csv,
-        file_name='filtered_data.csv',
+        file_name=f'filtered_data_{current_time}.csv',
         mime='text/csv'
+    )
+    
+    # Create a download button for the JSON file
+    st.download_button(
+        label="Download filters as JSON",
+        data=query,
+        file_name=f'query_params_{current_time}.json',
+        mime='application/json'
     )
 
 def add_auto_train_manager():

--- a/code/util/streamlit.py
+++ b/code/util/streamlit.py
@@ -657,6 +657,8 @@ def add_dot_property_mapper():
 def data_selector():
             
     with st.expander(f'Session selector', expanded=True):
+        # --- add a download button ---
+        _add_download_filtered_session()
         
         with st.expander(f"Filtered: {len(st.session_state.df_session_filtered)} sessions, "
                          f"{len(st.session_state.df_session_filtered.h2o.unique())} mice", expanded=False):
@@ -677,12 +679,24 @@ def data_selector():
         if cols[1].button('all'):
             st.session_state.df_selected_from_plotly = st.session_state.df_session_filtered
             st.rerun()
-            
         
         if cols[2].button('❌ '):
             st.session_state.df_selected_from_plotly = pd.DataFrame(columns=['h2o', 'session'])
             st.session_state.df_selected_from_dataframe = pd.DataFrame(columns=['h2o', 'session'])
             st.rerun()
+                    
+def _add_download_filtered_session():
+    """Download the master table of the filtered session"""
+    # Convert DataFrame to CSV format
+    csv = st.session_state.df_session_filtered.to_csv(index=False)
+
+    # Create a download button
+    st.download_button(
+        label="💾 Download filtered df",
+        data=csv,
+        file_name='filtered_data.csv',
+        mime='text/csv'
+    )
 
 def add_auto_train_manager():
 

--- a/code/util/streamlit.py
+++ b/code/util/streamlit.py
@@ -697,7 +697,7 @@ def _add_download_filtered_session():
                if 'filter' in key}
     query = json.dumps(filters, indent=4) 
     
-    current_time = datetime.now().strftime("%Y%m%d_%H%M%S")
+    current_time = datetime.now().strftime("%Y%m%d")
     
     # Create download buttons
     st.download_button(

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -84,7 +84,7 @@ RUN pip install -U --no-cache-dir \
     smmap==5.0.0 \
     statannotations==0.5.0 \
     statsmodels==0.13.5 \
-    streamlit==1.37.0 \
+    streamlit==1.31.0 \
     streamlit-aggrid==0.3.5 \
     streamlit-nested-layout==0.1.1 \
     streamlit-plotly-events==0.0.6 \

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -19,78 +19,96 @@ RUN pip install -U --no-cache-dir \
     blinker==1.5 \
     botocore==1.27.59 \
     cachetools==5.2.0 \
-    certifi==2022.9.24 \
+    certifi \
     charset-normalizer==2.1.1 \
     click==8.1.3 \
     commonmark==0.9.1 \
     contourpy==1.0.6 \
     cycler==0.11.0 \
     decorator==5.1.1 \
+    dill==0.3.6 \
+    distlib==0.3.4 \
     entrypoints==0.4 \
+    extra-streamlit-components==0.1.56 \
     fonttools==4.38.0 \
     frozenlist==1.3.3 \
     fsspec==2022.11.0 \
     gitdb==4.0.9 \
-    gitpython==3.1.29 \
+    GitPython==3.1.29 \
+    h5py==3.8.0 \
+    hdmf==3.5.2 \
     idna==3.4 \
     importlib-metadata==5.0.0 \
-    jinja2==3.1.2 \
+    Jinja2==3.1.2 \
     jmespath==1.0.1 \
     jsonschema==4.17.1 \
     kiwisolver==1.4.4 \
-    markupsafe==2.1.1 \
+    MarkupSafe==2.1.1 \
     matplotlib==3.6.2 \
     multidict==6.0.2 \
     nptyping==2.4.1 \
     numpy==1.23.5 \
     packaging==21.3 \
-    pandas==1.5.3 \
-    pillow==9.3.0 \
+    pandas==1.5.2 \
+    patsy==0.5.3 \
+    Pillow==9.3.0 \
+    pipenv==2022.5.2 \
+    platformdirs==2.5.2 \
     plotly==5.11.0 \
     protobuf==3.20.3 \
+    psrecord==1.2 \
+    psutil==5.9.4 \
     pyarrow==10.0.1 \
     pydeck==0.8.0 \
-    pygments==2.13.0 \
-    pympler==1.0.1 \
+    Pygments==2.13.0 \
+    pyinstrument==4.1.1 \
+    Pympler==1.0.1 \
     pynrrd==1.0.0 \
+    pynwb==2.3.1 \
     pyparsing==3.0.9 \
     pyrsistent==0.19.2 \
     python-dateutil==2.8.2 \
     python-decouple==3.6 \
     pytz==2022.6 \
     pytz-deprecation-shim==0.1.0.post0 \
-    requests==2.28.1 \
+    requests==2.31.0 \
     rich==12.6.0 \
+    ruamel.yaml==0.17.21 \
+    ruamel.yaml.clib==0.2.7 \
     s3fs==2022.11.0 \
     scipy==1.10.0 \
+    scikit-learn==1.3.2 \
+    seaborn==0.11.2 \
     semver==2.13.0 \
     six==1.16.0 \
     smmap==5.0.0 \
-    streamlit==1.31.0 \
+    statannotations==0.5.0 \
+    statsmodels==0.13.5 \
+    streamlit==1.37.0 \
     streamlit-aggrid==0.3.5 \
     streamlit-nested-layout==0.1.1 \
     streamlit-plotly-events==0.0.6 \
+    streamlit-profiler==0.2.4 \
     tenacity==8.1.0 \
     toml==0.10.2 \
     toolz==0.12.0 \
     tornado==6.2 \
-    typing-extensions==4.9.0 \
+    typing_extensions==4.9.0 \
     tzdata==2022.6 \
     tzlocal==4.2 \
     urllib3==1.26.13 \
     validators==0.20.0 \
+    virtualenv==20.14.1 \
+    virtualenv-clone==0.5.7 \
     watchdog==2.1.9 \
     wrapt==1.14.1 \
     yarl==1.8.1 \
     zipp==3.10.0 \
-    extra_streamlit_components \
-    statsmodels \
-    statannotations \
-    seaborn \
-    pynwb --ignore-installed ruamel.yaml\
-    git+https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training.git@main\
-    pygwalker \
-    scikit-learn==1.4
+    git+https://github.com/AllenNeuralDynamics/aind-foraging-behavior-bonsai-automatic-training.git@main \
+    pygwalker==0.4.7 \
+    aind-data-access-api[docdb]==0.13.0 \
+    streamlit-dynamic-filters==0.1.9
+
 
 ADD "https://github.com/coder/code-server/releases/download/v4.21.1/code-server-4.21.1-linux-amd64.tar.gz" /.code-server/code-server.tar.gz
 


### PR DESCRIPTION
- Added two download buttons for the filtered master table

<image src="https://github.com/user-attachments/assets/babc9513-9683-45f9-81a8-c8463a13b137" width=300>

- Example downloaded dataframe: [filtered_data_20240815.csv](https://github.com/user-attachments/files/16630836/filtered_data_20240815.csv)

- Example downloaded json: [query_params_20240815.json](https://github.com/user-attachments/files/16630837/query_params_20240815.json)

- (Optional) for reproducibility, you can always copy the full URL in the browser to recover the filter states. For example, this [URL](https://codeocean.allenneuraldynamics.org/cw/22a48106-53d9-4b8f-afe3-511ad1721251/proxy/8501/?filter_subject_id=736205&session_plot_selected_draw_types=1.+Choice+history&session_plot_selected_draw_types=2.+Lick+analysis&session_plot_selected_draw_types=3.+Logistic+regression+%28Su2022%29&session_plot_selected_draw_types=4.+Logistic+regression+%28Bari2019%29&session_plot_selected_draw_types=5.+Logistic+regression+%28Hattori2019%29&session_plot_selected_draw_types=6.+Logistic+regression+%28Miller2021%29&x_y_plot_if_use_x_quantile_all=False&x_y_plot_selected_color_map=Plotly&filter_session=0.95&filter_session=10.5&x_y_plot_line_width=2.0&auto_training_curriculum_version=1.0&auto_training_curriculum_schema_version=1.0&x_y_plot_if_aggr_all=True&x_y_plot_if_use_x_quantile_group=False&tab_id=tab_auto_train_history&x_y_plot_group_by=h2o&x_y_plot_aggr_method_group=lowess&auto_training_history_x_axis=date&x_y_plot_size_mapper_gamma=1.0&if_load_bpod_sessions=False&auto_training_curriculum_name=Uncoupled+Baiting&x_y_plot_figure_height=900&session_plot_number_cols=3&x_y_plot_smooth_factor=5&x_y_plot_size_mapper_range=3&x_y_plot_size_mapper_range=20&x_y_plot_yname=foraging_performance_random_seed&filter_task=Uncoupled+Baiting&filter_task=Coupled+Baiting&x_y_plot_if_show_diagonal=False&auto_training_history_sort_by=first_date&x_y_plot_q_quantiles_group=20&to_filter_columns=subject_id&to_filter_columns=task&to_filter_columns=session&to_filter_columns=finished_trials&to_filter_columns=foraging_eff&x_y_plot_size_mapper=finished_trials&x_y_plot_xname=session&auto_training_history_sort_order=descending&x_y_plot_dot_size=10&session_plot_mode=sessions+selected+from+table+or+plot&auto_training_history_recent_weeks=8&filter_foraging_eff=0.6189812747313238&filter_foraging_eff=0.8730957614651463&x_y_plot_aggr_method_all=mean+%2B%2F-+sem&x_y_plot_if_show_dots=True&table_height=300&x_y_plot_font_size_scale=1.0&x_y_plot_dot_opacity=0.3&x_y_plot_if_aggr_each_group=True&x_y_plot_figure_width=1300&x_y_plot_q_quantiles_all=20&filter_finished_trials=214.7&filter_finished_trials=655.2) can reproduce the two downloaded files.