### PR TITLE
fix (docDB): fetching dynamic foraging sessions by software name

### DIFF
--- a/code/util/fetch_data_docDB.py
+++ b/code/util/fetch_data_docDB.py
@@ -17,7 +17,7 @@ from aind_data_access_api.document_db import MetadataDbClient
 @st.cache_data(ttl=3600*12) # Cache the df_docDB up to 12 hours
 def load_data_from_docDB():
     client = load_client()
-    df = fetch_fip_data(client)
+    df = fetch_dynamic_foraging_data(client)
     return df
 
 @st.cache_resource
@@ -109,33 +109,32 @@ def strip_dict_for_id(co_asset_id_dict_list):
             
     return result_list                   
 
-def fetch_fip_data(client):
-    # To compare the FIP pipeline with my temporary pipeline for all behavior sessions, we should 
-    # query "behavior" from the data_description.modality.abbreviation field.
-    logger.warning("fetching 'behavior' records...")
-    modality_results = client.retrieve_docdb_records(
-        filter_query={"data_description.modality.abbreviation": "behavior"},
+def fetch_dynamic_foraging_data(client):
+    # To compare the new FIP pipeline with my temporary pipeline for all dynamic foraging sessions,
+    # let's directly query the software name
+    logger.warning("fetching 'dynamic foraging' in software name...")
+    software_name_results = client.retrieve_docdb_records(
+        filter_query={"session.data_streams.software.name": "dynamic-foraging-task",
+                      "name": {"$not": {"$regex": ".*processed.*"}}, # only raw data
+                      },
         paginate_batch_size=500
     )              
-    logger.warning(f"found {len(modality_results)} results")
+    logger.warning(f"found {len(software_name_results)} results")
 
     # there are more from the past that didn't specify modality correctly. 
     # until this is fixed, need to guess by asset name 
     logger.warning("fetching FIP records by name...")
-    name_results = client.retrieve_docdb_records(
+    name_FIP_results = client.retrieve_docdb_records(
         filter_query={"name": {"$regex": "^FIP.*"}},
         paginate_batch_size=500
     )
-    logger.warning(f"found {len(name_results)} results")
+    logger.warning(f"found {len(name_FIP_results)} results")
 
     # in case there is overlap between these two queries, filter down to a single list with unique IDs
-    unique_results_by_id = {**{ r['_id']: r for r in modality_results }, **{ r['_id']: r for r in name_results }}
+    unique_results_by_id = {**{ r['_id']: r for r in software_name_results }, **{ r['_id']: r for r in name_FIP_results }}
     results = list(unique_results_by_id.values())
     logger.warning(f"found {len(results)} unique results")
-    
-    # filter out results with 'processed' in the name because I can't rely on data_description.data_level :(
-    results = [ r for r in results if not 'processed' in r['name'] ]
-    
+        
     # make a dataframe
     records_df = pd.DataFrame.from_records([map_record_to_dict(d) for d in results ])
     

--- a/code/util/fetch_data_docDB.py
+++ b/code/util/fetch_data_docDB.py
@@ -43,7 +43,7 @@ def fetch_individual_procedures(r):
 def fetch_fiber_probes(r):
     probes = []
     for sp in fetch_individual_procedures(r):
-        if sp['procedure_type'] == 'Fiber implant':
+        if sp.get('procedure_type') == 'Fiber implant':
             probes += sp['probes']
     return probes
                 

--- a/code/util/fetch_data_docDB.py
+++ b/code/util/fetch_data_docDB.py
@@ -110,10 +110,11 @@ def strip_dict_for_id(co_asset_id_dict_list):
     return result_list                   
 
 def fetch_fip_data(client):
-    # search for records that have the "fib" (for fiber photometry) modality in data_description
-    logger.warning("fetching 'fib' records...")
+    # To compare the FIP pipeline with my temporary pipeline for all behavior sessions, we should 
+    # query "behavior" from the data_description.modality.abbreviation field.
+    logger.warning("fetching 'behavior' records...")
     modality_results = client.retrieve_docdb_records(
-        filter_query={"data_description.modality.abbreviation": "fib"},
+        filter_query={"data_description.modality.abbreviation": "behavior"},
         paginate_batch_size=500
     )              
     logger.warning(f"found {len(modality_results)} results")


### PR DESCRIPTION
Change the way we fetch dynamic foraging sessions (w/ or w/o FIP) from docDB

Previously we use `"data_description.modality.abbreviation": "fib"`, which was supposed to get "fib" sessions only. But because of another error in generating `data_description.modality`, this actually fetched all behavior sessions processed by the new FIP pipeline. As a result, we saw almost matched sessions between this query and my temporary pipeline.

However, the error in `data_description.modality` has been recently fixed. To continue properly comparing _dynamic foraging sessions_ from both pipelines, this PR changes the query to 

```python
{
  "session.data_streams.software.name": "dynamic-foraging-task",
  "name": {"$not": {"$regex": ".*processed.*"}},  # only raw data
}
```
I think this is the most direct way to query all "dynamic foraging sessions" at this point.

- See details in https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/1056, in particular [this comment](https://github.com/AllenNeuralDynamics/dynamic-foraging-task/issues/1056#issuecomment-2495197666)
- Two caveats:
    - Some older sessions may not have correct `session.data_streams.software.name` (this is not necessarily a problem since our goal is to ensure all uploaded data have the correct fields)
    - The new query also includes dynamic foraging sessions uploaded by the ephys pipeline (but these sessions won't have "processed" asset generated by the FIP pipeline)

- Next, I'll create venn diagrams to directly compare different queries.